### PR TITLE
Make tree/2 type transparent

### DIFF
--- a/src/splay_tree.erl
+++ b/src/splay_tree.erl
@@ -36,7 +36,7 @@
 -opaque tree() :: maybe_tree_node().
 %% A splay tree.
 
--type tree(_Key, _Vlaue) :: tree().
+-type tree(_Key, _Value) :: tree().
 %% A splay tree.
 
 -type key() :: any().

--- a/src/splay_tree.erl
+++ b/src/splay_tree.erl
@@ -36,7 +36,7 @@
 -opaque tree() :: maybe_tree_node().
 %% A splay tree.
 
--opaque tree(_Key, _Vlaue) :: maybe_tree_node().
+-type tree(_Key, _Vlaue) :: tree().
 %% A splay tree.
 
 -type key() :: any().


### PR DESCRIPTION
When writing some code using splay_tree like below, 

```erlang
-module(tree_type).

-export([f/0]).

-record(r, {tree = splay_tree:new() :: splay_tree:tree(atom(), integer())}).

f() -> #r{}.
```

I got the following dialyzer error.

```erlang
src/tree_type.erl
   7: Function f/0 has no local return
   7: The attempt to match a term of type splay_tree:tree(atom(),integer()) against the record field 'tree' declared to be of type splay_tree:tree(atom(),integer()) breaks the opaqueness of the term
```

This is because, although `tree/0` and `tree/2` are both aliases of `maybe_tree_node()`, `tree/2` type is an opaque type so that dialyzer regards `splay_tree:new() :: tree() =/= tree(atom(), integer())`.

So I make `tree/2` type transparent and define `tree/2` as an alias of `tree/0`.

And I fixed a typo too.